### PR TITLE
Fix PowerShell issue with relative paths

### DIFF
--- a/builders/build-boost.ps1
+++ b/builders/build-boost.ps1
@@ -1,5 +1,5 @@
-using module "./builders/win-boost-builder.psm1"
-using module "./builders/nix-boost-builder.psm1"
+using module "./win-boost-builder.psm1"
+using module "./nix-boost-builder.psm1"
 
 <#
 .SYNOPSIS

--- a/builders/nix-boost-builder.psm1
+++ b/builders/nix-boost-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/boost-builder.psm1"
+using module "./boost-builder.psm1"
 
 class NixBoostBuilder : BoostBuilder {
     <#

--- a/builders/win-boost-builder.psm1
+++ b/builders/win-boost-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/boost-builder.psm1"
+using module "./boost-builder.psm1"
 
 
 class WinBoostBuilder : BoostBuilder {


### PR DESCRIPTION
PowerShell 7.1.0 introduces breaking changes that affect relative paths. Boost packages generation fails with the following error:
```
The specified module '/home/runner/work/boost-versions/boost-versions/builders/builders/win-boost-builder.psm1' was not loaded because no valid module file was found in any module directory.
```

In scope of this PR we prepared fix for this issue.

Related issue: [#1473](https://github.com/actions/virtual-environments-internal/issues/1473)