### PR TITLE
Update README and change maintenance state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Boost for Actions
+
+**Please note: This repository is deprecated and should no longer be used. The team at GitHub has ceased maintaining it or making and accepting code contributions.**
+
 This repository contains the code and scripts that we use to prepare Boost packages used in [virtual-environments](https://github.com/actions/virtual-environments).  
 The file [versions-manifest.json](./versions-manifest.json) contains the list of available and released versions.  
 
 > Caution: this is prepared for and only permitted for use by actions `virtual-environments`.
 
-**Status**: Currently under development and in use for beta and preview actions. This repo is undergoing rapid changes.
-
-## Adding new versions
-We are trying to prepare packages for new versions of Boost as soon as they are released. Please open an issue in [virtual-environments](https://github.com/actions/virtual-environments) repository if any versions are missing.
+**Status**: Unmaintaned.
 
 ## Contribution
 Contributions are welcome! See [Contributor's Guide](./CONTRIBUTING.md) for more details about contribution process and code structure


### PR DESCRIPTION
Recently, we, virtual-environments mainatiners, stopped providing Boost on our images, so this repo should be marked as unmaintained and archived. 
I updated README and added a note about repo maintenance status.